### PR TITLE
Fixing by moving setInterval to the correct position

### DIFF
--- a/content.js
+++ b/content.js
@@ -31,12 +31,8 @@ function hideYoutubeShorts(tag, nearest) {
 }
 
 function hideAllYoutubeShortsElements() {
-
     hideYoutubeShorts(h2_tag, dismissible_id);
     hideYoutubeShorts(div_tag, a_tag);
-
-    setInterval(hideAllYoutubeShortsElements, 1000);
-
 }
 
-hideAllYoutubeShortsElements();
+setInterval(hideAllYoutubeShortsElements, 1000);


### PR DESCRIPTION
This addresses #1 

The setInterval had by accident been placed in the hideAllYoutubeShortsElements function.
This is result in a continues creation of new functions calls.